### PR TITLE
Correct naming of web_assets.dna, from relative devhub-dnas repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ run-holochain:
 	npx holochain-backdrop --admin-port 35678 --config holochain/config.yaml -vv
 reset-holochain:
 	rm -rf holochain tests/AGENT* tests/*_HASH
-dna_packages:		dnas/dnarepo.dna dnas/happs.dna dnas/webassets.dna
+dna_packages:		dnas/dnarepo.dna dnas/happs.dna dnas/web_assets.dna
+	echo "Run 'make copy-from-local' to access DNAs from ../devhub-dnas repo (run 'make build' there)"
 setup:			dna_packages
 	node tests/setup.js
 setup-%:		dna_packages
@@ -20,15 +21,16 @@ dnas:
 zome_wasm:
 	mkdir $@
 dnas/%.dna:		dnas
-	$(error Download missing DNA ($*.dna) into location ./$@)
+	$(error Download missing DNA ($*.dna) into location ./$@ (eg. run `make copy-from-local`))
 
-copy-dnas-from-local:	dnas
-	cp ~/projects/devhub-dnas/bundled/dnarepo.dna		dnas/dnarepo.dna
-	cp ~/projects/devhub-dnas/bundled/happs.dna		dnas/happs.dna
-	cp ~/projects/devhub-dnas/bundled/web_assets.dna	dnas/webassets.dna
+copy-dnas-from-local:
+	cp ../devhub-dnas/bundled/dnarepo.dna		dnas/dnarepo.dna
+	cp ../devhub-dnas/bundled/happs.dna		dnas/happs.dna
+	cp ../devhub-dnas/bundled/web_assets.dna	dnas/web_assets.dna
 copy-zomes-from-local:	zome_wasm
-	cp ~/projects/devhub-dnas/zomes/*.wasm			./zome_wasm/
+	cp ../devhub-dnas/zomes/*.wasm			./zome_wasm/
 
+copy-from-local: copy-dnas-from-local copy-zomes-from-local
 
 #
 # HTTP Server

--- a/Makefile
+++ b/Makefile
@@ -3,17 +3,24 @@ SHELL		= bash
 PROJECT_NAME	= devhub
 
 #
+# Project
+#
+package-lock.json:	package.json
+	touch $@
+node_modules:		package-lock.json
+	npm install
+	touch $@
+#
 # Runtime Setup
 #
-run-holochain:
+run-holochain:		node_modules
 	npx holochain-backdrop --admin-port 35678 --config holochain/config.yaml -vv
-reset-holochain:
+reset-holochain:	node_modules
 	rm -rf holochain tests/AGENT* tests/*_HASH
 dna_packages:		dnas/dnarepo.dna dnas/happs.dna dnas/web_assets.dna
-	echo "Run 'make copy-from-local' to access DNAs from ../devhub-dnas repo (run 'make build' there)"
-setup:			dna_packages
+setup:			dna_packages node_modules
 	node tests/setup.js
-setup-%:		dna_packages
+setup-%:		dna_packages node_modules
 	node tests/setup.js $*
 
 dnas:
@@ -23,12 +30,12 @@ zome_wasm:
 dnas/%.dna:		dnas
 	$(error Download missing DNA ($*.dna) into location ./$@ (eg. run `make copy-from-local`))
 
-copy-dnas-from-local:
-	cp ../devhub-dnas/bundled/dnarepo.dna		dnas/dnarepo.dna
-	cp ../devhub-dnas/bundled/happs.dna		dnas/happs.dna
-	cp ../devhub-dnas/bundled/web_assets.dna	dnas/web_assets.dna
+copy-dnas-from-local:	dnas
+	cp ../devhub-dnas/bundled/*.dna			./dnas/
+	touch dnas/*.dna
 copy-zomes-from-local:	zome_wasm
 	cp ../devhub-dnas/zomes/*.wasm			./zome_wasm/
+	touch zome_wasm/*.wasm
 
 copy-from-local: copy-dnas-from-local copy-zomes-from-local
 

--- a/tests/add_devhub_to_devhub.js
+++ b/tests/add_devhub_to_devhub.js
@@ -150,7 +150,7 @@ function print( msg, ...args ) {
 	    "version":		1,
 	    "changelog":	"...",
 	    "zomes": [{
-		"name":		"web_assets",
+		"name":		"webassets",
 		"zome":		zome3.$id,
 		"version":	zome3_version1.$id,
 		"resource":	zome3_version1.mere_memory_addr,
@@ -186,7 +186,7 @@ function print( msg, ...args ) {
 		}, {
 		    "id": "webassets",
 		    "dna": {
-			"path": `./webassets.dna`,
+			"path": `./web_assets.dna`,
 		    },
 		    "clone_limit": 0,
 		}],

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -15,7 +15,7 @@ if ( process.env.LOG_LEVEL )
 
 const DNAREPO				= path.resolve( __dirname, "../dnas/dnarepo.dna" );
 const HAPPS				= path.resolve( __dirname, "../dnas/happs.dna" );
-const WEBASSETS				= path.resolve( __dirname, "../dnas/webassets.dna" );
+const WEBASSETS				= path.resolve( __dirname, "../dnas/web_assets.dna" );
 const PORT				= 35678;
 
 const admin				= new AdminClient( PORT );


### PR DESCRIPTION
The devhub-dnas web_assets.dna Zome is called "webassets", but the file name is always "web_assets...".  Correct several instances where these conventions are confused.

Also, give a bit clearer direction on how to obtain the DNAs, and use relative paths to locate the likely "devhub-dnas/" directory relative to the "devhub-gui" repository.