### PR TITLE
Support HDK version tracking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ run-simple-http-server:
 #
 use-local-devhub-entities:
 	npm uninstall @holochain/devhub-entities
-	npm install ../devhub-dnas/js-devhub-entities/holochain-devhub-entities-0.5.0.tgz
+	npm install ../devhub-dnas/js-devhub-entities/holochain-devhub-entities-0.6.0.tgz
 use-npm-devhub-entities:
 	npm uninstall @holochain/devhub-entities
 	npm install @holochain/devhub-entities

--- a/package-lock.json
+++ b/package-lock.json
@@ -1116,9 +1116,9 @@
       }
     },
     "@holochain/devhub-entities": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@holochain/devhub-entities/-/devhub-entities-0.5.0.tgz",
-      "integrity": "sha512-zmV/O/E1lhTuAhstGQiitOPlfA+WhK0dFRJFU2F3xu1wcw024m6G04Zm0eS4WyrXhPuyJydOefOdNFNOMRrOcQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@holochain/devhub-entities/-/devhub-entities-0.6.0.tgz",
+      "integrity": "sha512-dHEfKpTmKnedax6w6OCaZTJoNT4K3yVW/+5ozsC3I7l3LW0RBi6QW+ZCAZF6xPF6NH7jKi96yytKRbCTLUVq0A==",
       "requires": {
         "@whi/entity-architect": "^0.1.2",
         "@whi/essence": "^0.1.1",
@@ -1845,9 +1845,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001251",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
-      "integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==",
+      "version": "1.0.30001312",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
+      "integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==",
       "dev": true
     },
     "chai": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/holochain/devhub-gui#readme",
   "dependencies": {
     "@babel/runtime": "^7.15.3",
-    "@holochain/devhub-entities": "^0.5.0",
+    "@holochain/devhub-entities": "^0.6.0",
     "@msgpack/msgpack": "^2.7.1",
     "@whi/weblogger": "^0.1.4",
     "gzip-js": "^0.3.2",

--- a/src/components.js
+++ b/src/components.js
@@ -1,6 +1,12 @@
 const { Logger }			= require('@whi/weblogger');
 const log				= new Logger("components");
 
+const { HoloHashes }			= require('@holochain/devhub-entities');
+const { EntryHash,
+	HeaderHash,
+	AgentPubKey,
+	DnaHash }			= HoloHashes;
+
 
 const DeprecationAlert = {
     "props": {
@@ -530,6 +536,141 @@ const Loading = {
 <slot v-else></slot>`,
 };
 
+const HoloHash = {
+    "props": {
+	"hash": {
+	    "required": true,
+	    validator (value) {
+		if ( value instanceof HoloHashes.HoloHash )
+		    return true;
+
+		try {
+		    new HoloHashes.HoloHash(value);
+		    return true;
+		} catch (err) {
+		    return false;
+		}
+	    }
+	},
+	"chars": {
+	    "type": Number,
+	    "default": 5,
+	},
+    },
+    data () {
+	return {
+	    "holohash": new HoloHashes.HoloHash( this.hash ),
+	    "hash_str": String( this.hash ),
+	    "full_hash": false,
+	};
+    },
+    "computed": {
+	hash_repr () {
+	    return this.snip( this.hash_str, 5 );
+	},
+    },
+    "methods": {
+	appearance_cls () {
+	    return {
+		"bg-primary":	this.holohash instanceof AgentPubKey,
+		"bg-light":	this.holohash instanceof EntryHash,
+		"text-dark":	this.holohash instanceof EntryHash,
+		"bg-secondary":	this.holohash instanceof HeaderHash,
+		"bg-danger":	this.holohash instanceof DnaHash,
+	    };
+	},
+	toggleFullHash () {
+	    this.full_hash	= !this.full_hash;
+	},
+    },
+    "template": `
+<span class="badge font-monospace" :class="appearance_cls()" :title="hash_str" @dblclick="toggleFullHash()">{{ full_hash ? hash_str : hash_repr }}</span>
+`,
+};
+
+const ZomeCard = {
+    "props": {
+	"entity": {
+	    "type": Object,
+	    "required": true,
+	},
+    },
+    data () {
+	return {
+	    "unique_id": "collapse_" + String( Math.random() ).slice(2),
+	};
+    },
+    "template": `
+<div class="card entity-card border-warning mb-3">
+    <div class="entity-card-header text-warning">Zome</div>
+    <div class="card-body">
+        <div class="float-end">
+            <holohash :hash="entity.$id"></holohash>
+        </div>
+        <h5 class="card-title">{{ entity.name }} <small class="fw-1" :title="entity.published_at">({{ $filters.time( entity.published_at ) }})</small></h5>
+        <div class="float-end">
+            <a data-bs-toggle="collapse" :href="'#' + unique_id">expand</a>
+        </div>
+        <p class="card-text mb-0">{{ entity.description || "No description" }}</p>
+        <div class="collapse" :id="unique_id">
+            <dl class="row mt-3 mb-0">
+                <template v-if="entity.developer">
+                    <dt class="col-sm-4 text-end">Created by</dt>
+                    <dd class="col-sm-8"><holohash :hash="entity.developer.pubkey"></holohash></dd>
+                </template>
+
+                <dt class="col-sm-4 text-end">Last updated</dt>
+                <dd class="col-sm-8">{{ $filters.time( entity.last_updated ) }}</dd>
+            </dl>
+        </div>
+    </div>
+</div>`,
+};
+
+const ZomeVersionCard = {
+    "props": {
+	"entity": {
+	    "type": Object,
+	    "required": true,
+	},
+	"name": {
+	    "type": String,
+	    "required": true,
+	},
+    },
+    data () {
+	return {
+	    "unique_id": "collapse_" + String( Math.random() ).slice(2),
+	};
+    },
+    "template": `
+<div class="card entity-card border-warning mb-3">
+    <div class="entity-card-header text-warning">Zome</div>
+    <div class="card-body">
+        <div class="float-end">
+            <holohash :hash="entity.$id"></holohash>
+        </div>
+        <h5 class="card-title">{{ name }} <small class="fw-1" :title="entity.published_at">({{ $filters.time( entity.published_at ) }})</small></h5>
+        <div class="float-end">
+            <a data-bs-toggle="collapse" :href="'#' + unique_id">expand</a>
+        </div>
+        <p class="card-text mb-0"><strong>v{{ entity.version }}</strong> &mdash; HDK v{{ entity.hdk_version }}</p>
+        <div class="collapse" :id="unique_id">
+            <dl class="row mt-3 mb-0">
+                <dt class="col-sm-4 text-end">Last updated</dt>
+                <dd class="col-sm-8">{{ $filters.time( entity.last_updated ) }}</dd>
+
+                <dt class="col-sm-4 text-end">Resource Address</dt>
+                <dd class="col-sm-8"><holohash :hash="entity.mere_memory_addr"></holohash></dd>
+
+                <dt class="col-sm-4 text-end">Resource Hash</dt>
+                <dd class="col-sm-8"><code>{{ entity.mere_memory_hash }}</dd>
+            </dl>
+        </div>
+    </div>
+</div>`,
+};
+
 
 module.exports = {
     "deprecation-alert":	DeprecationAlert,
@@ -544,4 +685,7 @@ module.exports = {
     "search":			Search,
     "placeholder":		Placeholder,
     "loading":			Loading,
+    "holohash":			HoloHash,
+    "zome-card":		ZomeCard,
+    "zome-version-card":	ZomeVersionCard,
 };

--- a/src/dna_version_controllers.js
+++ b/src/dna_version_controllers.js
@@ -30,31 +30,35 @@ module.exports = async function ( client ) {
 		    "input": {
 			"version": null,
 			"changelog": null,
+			"hdk_version": null,
 			"zomes": [],
 		    },
 		    "added_zomes": [],
 		    "zome_versions": {},
 		    "all_zome_versions": {},
-		    "zome_search_text": null,
+		    "zome_search_text": "",
 		    "validated": false,
 		    "saving": false,
+		    "show_search_list": false,
 		};
 	    },
 	    "computed": {
 		zomes () {
-		    return this.$store.getters.zomes().collection;
+		    return this.$store.getters.zomes( "all" ).collection;
 		},
 		$zomes () {
-		    return this.$store.getters.zomes().metadata;
+		    return this.$store.getters.zomes( "all" ).metadata;
 		},
 		form () {
 		    return this.$refs["form"];
 		},
+		previous_hdk_versions () {
+		    return this.$store.getters.hdk_versions.collection;
+		},
+		$previous_hdk_versions () {
+		    return this.$store.getters.hdk_versions.metadata;
+		},
 		filtered_zomes () {
-		    if ( !this.zome_search_text || this.zome_search_text.length < 3 ) {
-			return [];
-		    }
-
 		    return this.zomes.filter( zome => {
 			return zome.name.toLowerCase()
 			    .includes( this.zome_search_text.toLowerCase() )
@@ -67,11 +71,13 @@ module.exports = async function ( client ) {
 
 		if ( this.zomes.length === 0 )
 		    this.fetchZomes();
+
+		this.fetchHDKVersions();
 	    },
 	    "methods": {
 		async fetchZomes () {
 		    try {
-			await this.$store.dispatch("fetchZomes", { "agent": "me" });
+			await this.$store.dispatch("fetchAllZomes");
 
 			this.zomes.forEach( zome => {
 			    this.zome_versions[zome.$id] = null;
@@ -124,14 +130,17 @@ module.exports = async function ( client ) {
 		    this.input.zomes.splice( i, 1 );
 		},
 		addZome ( zome ) {
+		    log.normal("Adding zome:", zome );
 		    if ( zome === undefined )
 			return;
 
+		    log.info("Reset search");
 		    this.zome_search_text = "";
 
 		    if ( this.added_zomes.find( z => z.$id === zome.$id ) )
 			return;
 
+		    log.info("Fetch Zome versions for:", zome.$id );
 		    this.fetchZomeVersions ( zome.$id );
 		    this.added_zomes.push( zome );
 		    this.input.zomes.push({
@@ -156,6 +165,17 @@ module.exports = async function ( client ) {
 		    array_move( this.added_zomes, from_index, to_index );
 		    array_move( this.input.zomes, from_index, to_index );
 		},
+		async fetchHDKVersions () {
+		    await this.$store.dispatch("fetchHDKVersions");
+		},
+		selectHDKVersion ( hdk_version ) {
+		    this.input.hdk_version		= hdk_version;
+		},
+		hideResults () {
+		    setTimeout( () => {
+			this.show_search_list		= false;
+		    }, 100 );
+		}
 	    },
 	};
     };

--- a/src/filters.js
+++ b/src/filters.js
@@ -44,7 +44,37 @@ module.exports = {
 	    format			= `${date(d)}`;
 	    break;
 	default:
-	    format			= `${day(d)}, ${date(d)} @ ${time(d)}`; // "dddd, MMMM D (YYYY) @ HH:mm:ss";
+	    const delta_seconds		= Math.floor( (new Date() - d) / 1000 );
+
+	    let delta, term;
+
+	    // seconds since
+	    if ( delta_seconds < 60 ) {
+		delta			= delta_seconds;
+		term			= "second";
+	    }
+	    // minutes since
+	    else if ( delta_seconds < 3600 ) {
+		delta			= Math.floor( delta_seconds / 60 );
+		term			= "minute";
+	    }
+	    // hours since
+	    else if ( delta_seconds < 86400 ) {
+		delta			= Math.floor( delta_seconds / 3600 );
+		term			= "hour";
+	    }
+	    // days since
+	    else if ( delta_seconds < 2592000 ) {
+		delta			= Math.floor( delta_seconds / 86400 );
+		term			= "day";
+	    }
+	    // months since
+	    else if ( delta_seconds < 31536000 ) {
+		delta			= Math.floor( delta_seconds / 2592000 )
+		term			= "month";
+	    }
+
+	    format			= delta + " " + (delta > 1 ? `${term}s` : term) + " ago";
 	    break;
 	}
 

--- a/src/happ_release_controllers.js
+++ b/src/happ_release_controllers.js
@@ -34,14 +34,16 @@ module.exports = async function ( client ) {
 			    "manifest_version": "1",
 			    "roles": null,
 			},
+			"hdk_version": null,
 			"dnas": [],
 		    },
 		    "added_dnas": [],
 		    "dna_versions": {},
 		    "all_dna_versions": {},
-		    "dna_search_text": null,
+		    "dna_search_text": "",
 		    "validated": false,
 		    "saving": false,
+		    "show_search_list": false,
 		};
 	    },
 	    "computed": {
@@ -54,11 +56,13 @@ module.exports = async function ( client ) {
 		form () {
 		    return this.$refs["form"];
 		},
+		previous_hdk_versions () {
+		    return this.$store.getters.hdk_versions.collection;
+		},
+		$previous_hdk_versions () {
+		    return this.$store.getters.hdk_versions.metadata;
+		},
 		filtered_dnas () {
-		    if ( !this.dna_search_text || this.dna_search_text.length < 3 ) {
-			return [];
-		    }
-
 		    return this.dnas.filter( dna => {
 			return dna.name.toLowerCase()
 			    .includes( this.dna_search_text.toLowerCase() )
@@ -71,6 +75,8 @@ module.exports = async function ( client ) {
 
 		if ( this.dnas.length === 0 )
 		    this.fetchDnas();
+
+		this.fetchHDKVersions();
 	    },
 	    "methods": {
 		async fetchDnas () {
@@ -167,6 +173,17 @@ module.exports = async function ( client ) {
 		    array_move( this.added_dnas, from_index, to_index );
 		    array_move( this.input.dnas, from_index, to_index );
 		},
+		async fetchHDKVersions () {
+		    await this.$store.dispatch("fetchHDKVersions");
+		},
+		selectHDKVersion ( hdk_version ) {
+		    this.input.hdk_version		= hdk_version;
+		},
+		hideResults () {
+		    setTimeout( () => {
+			this.show_search_list		= false;
+		    }, 100 );
+		}
 	    },
 	};
     };
@@ -305,6 +322,10 @@ module.exports = async function ( client ) {
 		async fetchRelease () {
 		    try {
 			let release	= await this.$store.dispatch("fetchHappRelease", this.id );
+
+			release.dnas.forEach( (dna_ref) => {
+			    // fetch DNA version
+			});
 		    } catch (err) {
 			this.catchStatusCodes([ 404, 500 ], err );
 

--- a/src/static/css/bootstrap-holochain-theme.css
+++ b/src/static/css/bootstrap-holochain-theme.css
@@ -158,10 +158,16 @@ a.text-primary:hover {
 
 
 
+.badge {
+  padding: .5em .65em .25em !important;
+}
 .badge-md {
-  padding: .5em 1.2em;
+  padding: .5em 1.2em !important;
   font-size: 1rem;
   font-weight: 400;
+}
+.bg-primary {
+  background-color: #4820E3 !important;
 }
 
 
@@ -344,6 +350,15 @@ a.text-primary:hover {
 .card-body {
   font-size: .9rem;
   font-weight: 200;
+}
+.entity-card-header {
+  position: absolute;
+  top: -9px;
+  left: 10px;
+  background-color: white;
+  padding: 0 7px;
+  font-weight: 600;
+  text-transform: uppercase;
 }
 
 

--- a/src/templates/dnas/list.html
+++ b/src/templates/dnas/list.html
@@ -47,7 +47,7 @@
 		    <p>{{ dna.description }}</p>
 		</div>
 		<div class="col-4">
-		    <span class="badge badge-md bg-secondary">Created on {{ $filters.time( dna.published_at ) }}</span>
+		    <span class="badge badge-md bg-secondary">Created {{ $filters.time( dna.published_at ) }}</span>
 		</div>
 		<div class="col-auto">
 		    <router-link :to="'/dnas/' + dna.$id" class="btn btn-light">

--- a/src/templates/dnas/single.html
+++ b/src/templates/dnas/single.html
@@ -61,13 +61,23 @@
 		</div>
 		<div class="card-body">
 		    <dl class="row">
-			<dt class="col-sm-12"><placeholder :when="!$dna.current">{{ dna.developer.pubkey }}</placeholder></dt>
+			<dt class="col-sm-12">
+			    Agent ID
+			</dt>
+			<dd class="col-sm-12">
+			    <placeholder :when="!$dna.current">
+				<holohash :hash="dna.developer.pubkey"></holohash>
+			    </placeholder>
+			</dd>
+			<dt class="col-sm-12">
+			    External Links
+			</dt>
 			<dd class="col-sm-12">
 			    <placeholder :when="!$dna.current">
 				<span v-if="dna.developer.website">
 				    <a href="#" target="_blank">website</a>
 				</span>
-				<span v-else>No website</span>
+				<span v-else>None</span>
 			    </placeholder>
 			</dd>
 		    </dl>

--- a/src/templates/dnas/versions/create.html
+++ b/src/templates/dnas/versions/create.html
@@ -15,12 +15,35 @@
 		<textarea v-model="input.changelog" class="form-control font-monospace" rows="10" :disabled="saving"></textarea>
 	    </input-feedback>
 
+	    <div class="row">
+		<div class="col-6">
+		    <label class="form-label fw-6">HDK Version</label>
+		    <input-feedback>
+			<div class="input-group mb-3">
+			    <span class="input-group-text" id="basic-addon1">v</span>
+			    <input v-model="input.hdk_version" class="form-control" :disabled="saving" required>
+			</div>
+		    </input-feedback>
+		</div>
+		<div v-if="$previous_hdk_versions.loaded" class="col-6">
+		    <loading :when="!$previous_hdk_versions.current">
+			<label class="form-label">Versions on DevHub</label>
+			<select class="form-select" :disabled="saving || previous_hdk_versions.length === 0"
+				@change="selectHDKVersion( $event.target.value )">
+			    <option selected>Choose an HDK version</option>
+			    <option v-for="hdkv in previous_hdk_versions">{{ hdkv }}</option>
+			</select>
+		    </loading>
+		</div>
+	    </div>
+
 	    <label class="form-label fw-6">Search zomes</label>
 	    <div class="form-input-search" :class="{ 'show-results': filtered_zomes.length }">
-		<input type="text" class="form-control no-validate" placeholder="type at least 3 characters"
-		       v-model="zome_search_text" @keyup.enter="addZome( filtered_zomes[0] )">
+		<input type="text" class="form-control no-validate" placeholder="start typing a Zome name"
+		       v-model="zome_search_text" @keyup.enter="addZome( filtered_zomes[0] )"
+		       @focus="show_search_list = true" @blur="hideResults()">
 
-		<div class="list-group">
+		<div class="list-group" :class="{ 'd-none': !show_search_list }">
 		    <div class="list-group-item list-group-item-action d-flex align-items-center"
 			 v-for="zome in filtered_zomes">
 			<div class="flex-grow-1">
@@ -56,8 +79,9 @@
 				<div class="form-check form-check-inline"
 				     v-for="version in zome_versions[zome.$id]">
 				    <input class="form-check-input" type="radio" :name="'input.zomes[' + index + ']'"
-					   v-model="input.zomes[index].version" :value="version.$id" required :disabled="saving">
-				    <label class="form-check-label">v{{ version.version }}</label>
+					   v-model="input.zomes[index].version" :value="version.$id" required
+					   :disabled="saving || input.hdk_version !== version.hdk_version">
+				    <label class="form-check-label">v{{ version.version }} (HDK v{{ version.hdk_version }})</label>
 				</div>
 			    </input-feedback>
 			</div>

--- a/src/templates/dnas/versions/single.html
+++ b/src/templates/dnas/versions/single.html
@@ -63,17 +63,19 @@
 			<dt class="col-sm-12">Last Updated</dt>
 			<dd class="col-sm-12"><placeholder :when="!$version.current">{{ $filters.time( version.last_updated, "weekday+date" ) }}</placeholder></dd>
 
+			<dt class="col-sm-12">HDK Version</dt>
+			<dd class="col-sm-12"><placeholder :when="!$version.current">{{ version.hdk_version }}</placeholder></dd>
+
 			<dt class="col-sm-12">Resource Hash</dt>
 			<dd class="col-sm-12"><placeholder :when="!$version.current"><code>{{ version.wasm_hash }}</code></placeholder></dd>
 		    </dl>
 
-		    <list-group v-if="dna" :list="version.zomes" no-result-text="No Zomes" class="my-5" :loading="!$version.current">
-			<list-group-item v-for="zome in version.zomes">
-			    <h5 class="m-0">{{ zome.name }}</h5>
-			    <router-link :to="'/zomes/' + zome.zome + '/versions/' + zome.version">
-				<code>{{ zome.version }}</code>
-			    </router-link>
-			</list-group-item>
+		    <list-group v-if="dna" :list="Object.values(version.zomes)" no-result-text="No Zomes" class="my-5" :loading="!$version.current">
+			<router-link v-for="(zome_version, name) in version.zomes"
+				     class="text-decoration-none"
+				     :to="'/zomes/' + zome_version.for_zome + '/versions/' + zome_version.$id">
+			    <zome-version-card :name="name" :entity="zome_version"></zome-version-card>
+			</router-link>
 		    </list-group>
 
 		    <loading :when="!$version.current">

--- a/src/templates/happs/list.html
+++ b/src/templates/happs/list.html
@@ -47,7 +47,7 @@
 		    <p>{{ happ.description }}</p>
 		</div>
 		<div class="col-4">
-		    <span class="badge badge-md bg-secondary">Created on {{ $filters.time( happ.published_at ) }}</span>
+		    <span class="badge badge-md bg-secondary">Created {{ $filters.time( happ.published_at ) }}</span>
 		</div>
 		<div class="col-auto">
 		    <router-link :to="'/happs/' + happ.$id" class="btn btn-light">

--- a/src/templates/happs/releases/create.html
+++ b/src/templates/happs/releases/create.html
@@ -16,12 +16,35 @@
 			  :disabled="saving" required></textarea>
 	    </input-feedback>
 
-	    <label class="form-label fw-6">Search dnas</label>
-	    <div class="form-input-search" :class="{ 'show-results': filtered_dnas.length }">
-		<input type="text" class="form-control no-validate" placeholder="type at least 3 characters"
-		       v-model="dna_search_text" @keyup.enter="addDna( filtered_dnas[0] )">
+	    <div class="row">
+		<div class="col-6">
+		    <label class="form-label fw-6">HDK Version</label>
+		    <input-feedback>
+			<div class="input-group mb-3">
+			    <span class="input-group-text" id="basic-addon1">v</span>
+			    <input v-model="input.hdk_version" class="form-control" :disabled="saving" required>
+			</div>
+		    </input-feedback>
+		</div>
+		<div v-if="$previous_hdk_versions.loaded" class="col-6">
+		    <loading :when="!$previous_hdk_versions.current">
+			<label class="form-label">Versions on DevHub</label>
+			<select class="form-select" :disabled="saving || previous_hdk_versions.length === 0"
+				@change="selectHDKVersion( $event.target.value )">
+			    <option selected>Choose an HDK version</option>
+			    <option v-for="hdkv in previous_hdk_versions">{{ hdkv }}</option>
+			</select>
+		    </loading>
+		</div>
+	    </div>
 
-		<div class="list-group">
+	    <label class="form-label fw-6">Search DNAs</label>
+	    <div class="form-input-search" :class="{ 'show-results': filtered_dnas.length }">
+		<input type="text" class="form-control no-validate" placeholder="start typing a Zome name"
+		       v-model="dna_search_text" @keyup.enter="addDna( filtered_dnas[0] )"
+		       @focus="show_search_list = true" @blur="hideResults()">
+
+		<div class="list-group" :class="{ 'd-none': !show_search_list }">
 		    <div class="list-group-item list-group-item-action d-flex align-items-center"
 			 v-for="dna in filtered_dnas">
 			<div class="flex-grow-1">
@@ -37,7 +60,7 @@
 		</div>
 	    </div>
 
-	    <label class="form-label fw-6">Dnas</label>
+	    <label class="form-label fw-6">DNAs</label>
 	    <list-group :list="added_dnas" no-result-text="No DNAs have been added"
 			class="mt-0">
 		<list-group-item v-for="(dna, index) in added_dnas" class="py-3"
@@ -56,8 +79,9 @@
 				<div class="form-check form-check-inline"
 				     v-for="version in dna_versions[dna.$id]">
 				    <input class="form-check-input" type="radio" :name="'input.dnas[' + index + ']'"
-					   v-model="input.dnas[index].version" :value="version.$id" required :disabled="saving">
-				    <label class="form-check-label">v{{ version.version }}</label>
+					   v-model="input.dnas[index].version" :value="version.$id" required
+					   :disabled="saving || input.hdk_version !== version.hdk_version">
+				    <label class="form-check-label">v{{ version.version }} (HDK v{{ version.hdk_version }})</label>
 				</div>
 			    </input-feedback>
 			</div>

--- a/src/templates/happs/releases/single.html
+++ b/src/templates/happs/releases/single.html
@@ -63,6 +63,9 @@
 			<dt class="col-sm-12">Last Updated</dt>
 			<dd class="col-sm-12"><placeholder :when="!$release.current">{{ $filters.time( release.last_updated, "weekday+date" ) }}</placeholder></dd>
 
+			<dt class="col-sm-12">HDK Version</dt>
+			<dd class="col-sm-12"><placeholder :when="!$release.current">{{ release.hdk_version }}</placeholder></dd>
+
 			<dt class="col-sm-12">Resource Hash</dt>
 			<dd class="col-sm-12"><placeholder :when="!$release.current"><code>{{ release.dna_hash }}</code></placeholder></dd>
 		    </dl>

--- a/src/templates/happs/single.html
+++ b/src/templates/happs/single.html
@@ -72,9 +72,19 @@
 		</div>
 		<div class="card-body">
 		    <dl class="row">
-			<dt class="col-sm-12"><placeholder :when="!$happ.current">{{ happ.designer }}</placeholder></dt>
+			<dt class="col-sm-12">
+			    Agent ID
+			</dt>
 			<dd class="col-sm-12">
-			    <span>No website</span>
+			    <placeholder :when="!$happ.current">
+				<holohash :hash="happ.designer"></holohash>
+			    </placeholder>
+			</dd>
+			<dt class="col-sm-12">
+			    External Links
+			</dt>
+			<dd class="col-sm-12">
+			    None
 			</dd>
 		    </dl>
 		</div>

--- a/src/templates/happs/upload.html
+++ b/src/templates/happs/upload.html
@@ -40,6 +40,28 @@
 	    </div>
 	</div>
 
+	<div class="row">
+	    <div class="col-3">
+		<label class="form-label fw-6">HDK Version</label>
+		<input-feedback>
+		    <div class="input-group mb-3">
+			<span class="input-group-text" id="basic-addon1">v</span>
+			<input v-model="input.hdk_version" class="form-control" :disabled="saving" required>
+		    </div>
+		</input-feedback>
+	    </div>
+	    <div v-if="$previous_hdk_versions.loaded" class="col-3">
+		<loading :when="!$previous_hdk_versions.current">
+		    <label class="form-label">Versions on DevHub</label>
+		    <select class="form-select" :disabled="saving || previous_hdk_versions.length === 0"
+			    @change="selectHDKVersion( $event.target.value )">
+			<option selected>Choose an HDK version</option>
+			<option v-for="hdkv in previous_hdk_versions">{{ hdkv }}</option>
+		    </select>
+		</loading>
+	    </div>
+	</div>
+
 	<h2 class="mt-4">DNAs</h2>
 	<div v-if="Object.keys(dnas).length === 0" class="card col-6">
 	    <div class="card-body text-center">
@@ -94,7 +116,7 @@
 			<a class="list-group-item list-group-item-action"
 			   v-for="dna_version in sources.dna_version_search_results"
 			   @click="select_dna_version( sources.upload, dna_version )">
-			    <strong>v{{ dna_version.version }}</strong>
+			    <strong>v{{ dna_version.version }}</strong> <i>(HDK v{{ dna_version.hdk_version }})</i>
 			    &mdash;
 			    {{ $filters.time( dna_version.published_at, "weekday+date" ) }}
 			</a>
@@ -105,7 +127,7 @@
 		 class="card col-6 mt-2">
 		<div class="card-body">
 		    <a class="btn btn-outline-secondary btn-sm float-end"
-		       :class="{ 'disabled': missing_zome_version( sources ) || saving }"
+		       :class="{ 'disabled': missing_zome_version( sources ) || saving || !input.hdk_version }"
 		       @click="create_dna_version( sources )">
 			<span v-if="sources.saving"
 			      class="spinner-border spinner-border-sm me-3"></span>
@@ -166,7 +188,7 @@
 				    <a class="list-group-item list-group-item-action"
 				       v-for="zome_version in zome_sources.zome_version_search_results"
 				       @click="select_zome_version( zome_sources.upload, zome_version )">
-					<strong>v{{ zome_version.version }}</strong>
+					<strong>v{{ zome_version.version }}</strong> <i>(HDK v{{ zome_version.hdk_version }})</i>
 					&mdash; 
 					{{ $filters.time( zome_version.published_at, "weekday+date" ) }}
 				    </a>
@@ -176,7 +198,7 @@
 			<div v-else class="card">
 			    <div class="card-body">
 				<a class="btn btn-outline-secondary btn-sm float-end"
-				   :class="{ 'disabled': saving }"
+				   :class="{ 'disabled': saving || !input.hdk_version }"
 				   @click="create_zome_version( zome_name, zome_sources )">
 				    <span v-if="zome_sources.saving"
 					  class="spinner-border spinner-border-sm me-3"></span>

--- a/src/templates/zomes/list.html
+++ b/src/templates/zomes/list.html
@@ -47,7 +47,7 @@
 		    <p>{{ zome.description }}</p>
 		</div>
 		<div class="col-4">
-		    <span class="badge badge-md bg-secondary">Created on {{ $filters.time( zome.published_at ) }}</span>
+		    <span class="badge badge-md bg-secondary">Created {{ $filters.time( zome.published_at ) }}</span>
 		</div>
 		<div class="col-auto">
 		    <router-link :to="'/zomes/' + zome.$id" class="btn btn-light">

--- a/src/templates/zomes/single.html
+++ b/src/templates/zomes/single.html
@@ -61,13 +61,23 @@
 		</div>
 		<div class="card-body">
 		    <dl class="row">
-			<dt class="col-sm-12"><placeholder :when="!$zome.current">{{ zome.developer.pubkey }}</placeholder></dt>
+			<dt class="col-sm-12">
+			    Agent ID
+			</dt>
+			<dd class="col-sm-12">
+			    <placeholder :when="!$zome.current">
+				<holohash :hash="zome.developer.pubkey"></holohash>
+			    </placeholder>
+			</dd>
+			<dt class="col-sm-12">
+			    External Links
+			</dt>
 			<dd class="col-sm-12">
 			    <placeholder :when="!$zome.current">
 				<span v-if="zome.developer.website">
 				    <a href="#" target="_blank">website</a>
 				</span>
-				<span v-else>No website</span>
+				<span v-else>None</span>
 			    </placeholder>
 			</dd>
 		    </dl>

--- a/src/templates/zomes/versions/create.html
+++ b/src/templates/zomes/versions/create.html
@@ -10,6 +10,28 @@
 		<input type="number" v-model.number="input.version" class="form-control" :disabled="saving" required>
 	    </input-feedback>
 
+	    <div class="row">
+		<div class="col-6">
+		    <label class="form-label fw-6">HDK Version</label>
+		    <input-feedback>
+			<div class="input-group mb-3">
+			    <span class="input-group-text" id="basic-addon1">v</span>
+			    <input v-model="input.hdk_version" class="form-control" :disabled="saving" required>
+			</div>
+		    </input-feedback>
+		</div>
+		<div v-if="$previous_hdk_versions.loaded" class="col-6">
+		    <loading :when="!$previous_hdk_versions.current">
+			<label class="form-label">Versions on DevHub</label>
+			<select class="form-select" :disabled="saving || previous_hdk_versions.length === 0"
+				@change="selectHDKVersion( $event.target.value )">
+			    <option selected>Choose an HDK version</option>
+			    <option v-for="hdkv in previous_hdk_versions">{{ hdkv }}</option>
+			</select>
+		    </loading>
+		</div>
+	    </div>
+
 	    <label class="form-label fw-6">Changelog</label>
 	    <input-feedback>
 		<textarea v-model="input.changelog" class="form-control font-monospace" rows="10" :disabled="saving"></textarea>

--- a/src/templates/zomes/versions/single.html
+++ b/src/templates/zomes/versions/single.html
@@ -63,6 +63,9 @@
 			<dt class="col-sm-12">Last Updated</dt>
 			<dd class="col-sm-12"><placeholder :when="!$version.current">{{ $filters.time( version.last_updated, "weekday+date" ) }}</placeholder></dd>
 
+			<dt class="col-sm-12">HDK Version</dt>
+			<dd class="col-sm-12"><placeholder :when="!$version.current">{{ version.hdk_version }}</placeholder></dd>
+
 			<dt class="col-sm-12">Resource Hash</dt>
 			<dd class="col-sm-12"><placeholder :when="!$version.current"><code>{{ version.mere_memory_hash }}</code></placeholder></dd>
 		    </dl>

--- a/src/zome_version_controllers.js
+++ b/src/zome_version_controllers.js
@@ -21,6 +21,7 @@ module.exports = async function ( client ) {
 			"version": null,
 			"changelog": null,
 			"zome_bytes": null,
+			"hdk_version": null,
 		    },
 		    "zome_file": null,
 		    "validated": false,
@@ -39,9 +40,17 @@ module.exports = async function ( client ) {
 
 		    return `Selected file "<strong class="font-monospace">${file.name}</strong>" (${this.$filters.number(file.size)} bytes)`;
 		},
+		previous_hdk_versions () {
+		    return this.$store.getters.hdk_versions.collection;
+		},
+		$previous_hdk_versions () {
+		    return this.$store.getters.hdk_versions.metadata;
+		},
 	    },
 	    async created () {
 		this.zome_id		= this.getPathId("zome");
+
+		this.fetchHDKVersions();
 	    },
 	    "methods": {
 		async file_selected ( event ) {
@@ -76,6 +85,12 @@ module.exports = async function ( client ) {
 			this.saving	= false;
 		    }
 		},
+		async fetchHDKVersions () {
+		    await this.$store.dispatch("fetchHDKVersions");
+		},
+		selectHDKVersion ( hdk_version ) {
+		    this.input.hdk_version	= hdk_version;
+		}
 	    },
 	};
     };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -112,7 +112,7 @@ module.exports = {
 	],
     },
     performance: {
-	maxEntrypointSize:	300_000, // 300kb
-	maxAssetSize:		300_000, // 300kb
+	maxEntrypointSize:	400_000, // 400kb
+	maxAssetSize:		400_000, // 400kb
     },
 };


### PR DESCRIPTION
### Changelog
- add HDK version input on Zome version, DNA version, and hApp release create pages
- fix DNA selection list on hApp release create page and Zome selection list on DNA version create page so that it shows all available options instead of just the current Agent's list
- add a relative date format
- add Holo hash badge with double click expansion for copying