### PR TITLE
fix: avoid error when publishing dna that contains zome with 0 dependencies

### DIFF
--- a/src/dna_version_controllers.js
+++ b/src/dna_version_controllers.js
@@ -834,7 +834,7 @@ module.exports = async function ( client ) {
 				    "version":		version.$id,
 				    "resource":		version.mere_memory_addr,
 				    "resource_hash":	version.mere_memory_hash,
-				    "dependencies":	Object.values( info.dependencies ).map( ref => ref.name ),
+				    "dependencies":	info.dependencies ? Object.values( info.dependencies ).map( ref => ref.name ) : [],
 				};
 			    }),
 			};


### PR DESCRIPTION
Resolves #31 (I'm guessing)

I haven't actually setup the app locally, but I'm guessing this is all you need to fix that issue.